### PR TITLE
vscode: change python.formatting.provider to black

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     ],
     "editor.tabSize": 2,
     "files.insertFinalNewline": true,
-    "python.formatting.provider": "autopep8",
+    "python.formatting.provider": "black",
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": false,
     "python.linting.pylintArgs": [


### PR DESCRIPTION
# Why This Is Needed

autopep8 is not installed as a dev dependency of this project.

# What Changed

## Fixed

- fixed issue where there wrong python formatting provider was being used
