### PR TITLE
vscode: remove invalid terraform extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
         "editorconfig.editorconfig",
-        "mauve.terraform",
         "ms-python.python",
         "ms-python.vscode-pylance",
         "njpwerner.autodocstring",


### PR DESCRIPTION
# Why This Is Needed

Invalid extension was being recommended.

# What Changed

## Removed

- removed recommendation for extension that no longer exists
