### PR TITLE
makefile: add docs, docs-changes, open-docs, & setup-npm targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: ## show this message
 	done
 
 docs: ## delete current HTML docs & build fresh HTML docs
-	@make -C docs clean html
+	@make -C docs docs
 
 docs-changes: ## build HTML docs; only builds changes detected by Sphinx
 	@make -C docs html

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: docs
+
 SHELL := /bin/bash
 
 help: ## show this message
@@ -15,6 +17,12 @@ help: ## show this message
 		printf '\033[0m'; \
 		printf "%s\n" $$help_info; \
 	done
+
+docs: ## delete current HTML docs & build fresh HTML docs
+	@make -C docs clean html
+
+docs-changes: ## build HTML docs; only builds changes detected by Sphinx
+	@make -C docs html
 
 fix-black: ## automatically fix all black errors
 	@poetry run black .
@@ -44,10 +52,15 @@ lint-pyright: ## run pyright
 	@npx pyright --venv-path ./
 	@echo ""
 
+open-docs: ## open docs (HTML files must already exists)
+	@make -C docs open
+
 run-pre-commit: ## run pre-commit for all files
 	@poetry run pre-commit run -a
 
-setup: setup-poetry setup-pre-commit ## setup dev environment
+setup: setup-poetry setup-pre-commit setup-npm ## setup dev environment
+
+setup-npm: ## install node dependencies with npm
 	@npm ci
 
 setup-poetry: ## setup python virtual environment

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ clean:
 	@rm -rf source/apidocs/*
 	@echo "Removed apidocs from previous build"
 
-docs: clean html open
+docs: clean html
 
 open:
 	@open build/html/index.html


### PR DESCRIPTION
# What Changed

## Added

- added `docs` target to build fresh, local HTML docs
- added `docs-changes` to build build local HTML docs
	- only changes detected by Shinx are built
- added `open-docs` to open local HTML docs
- added `setup-npm` to install node dependencies with npm
	- this was previously defined within the `setup` target
	- still run as the last step of `setup`

## Removed

- removed `open` from `docs/Makefile` `docs` target so it matches the top level target
