### PR TITLE
dependabot: change schedule to weekly, versioning-strategy comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,6 @@
 version: 2
 updates:
   - directory: /
-    labels:
-      - dependencies
-      - github/workflows
-      - github_actions
     open-pull-requests-limit: 5
     package-ecosystem: github-actions
     # reviewers:
@@ -21,38 +17,27 @@ updates:
     # reviewers:
     #   - ITProKyle
     schedule:
-      interval: daily
+      day: monday
+      interval: weekly
       time: "08:00"
       timezone: America/New_York
   - directory: /
-    ignore:
-      - dependency-name: boto3
-      - dependency-name: botocore
+    # ignore:
+    #   - dependency-name: boto3
+    #   - dependency-name: botocore
     labels:
       - dependencies
       - poetry
       - python
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     package-ecosystem: pip
     # reviewers:
     #   - ITProKyle
     schedule:
-      interval: daily
+      day: monday
+      interval: weekly
       time: "08:00"
       timezone: America/New_York
-  - directory: /docs
-    ignore:
-      - dependency-name: boto3
-      - dependency-name: botocore
-    labels:
-      - dependencies
-      - poetry
-      - python
-    open-pull-requests-limit: 5
-    package-ecosystem: pip
-    # reviewers:
-    #   - ITProKyle
-    schedule:
-      interval: daily
-      time: "08:00"
-      timezone: America/New_York
+    # versioning-strategy can be used for projects that need more control
+    # over when version constraints are changed.
+    # versioning-strategy: lockfile-only


### PR DESCRIPTION
# Why This Is Needed

Change dependabot frequency to reduce _noise_.

# What Changed

## Added

- added a comment about `versioning-strategy`

## Changed

- removed custom labels for github action updates
- commented out exclusion for boto3 & botocore
