### PR TITLE
fix issue cause docs to fail as build tools where failing during install

### DIFF
--- a/generic_template/__init__.py
+++ b/generic_template/__init__.py
@@ -1,0 +1,5 @@
+"""Blank file for Python transversal.
+
+This can be deleted or renamed to store the source code of your project.
+
+"""

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-"""Import classes."""


### PR DESCRIPTION
# Why This Is Needed

Docs were failing to build because the poetry build tools were failing to find the project when using pip to install the project.

# What Changed

## Changed

- renamed `src/` to `generic_template/`
