### PR TITLE
change labels to avoid conflict between release-drafter and dependabot

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,6 +5,22 @@
   - name: bug
     color: d73a4a
     description: Something isn't working
+  - name: changelog:major
+    color: ffffff
+    description: Major change resulting in a major release
+    # from_name: major  # uncomment if converting from previous labels
+  - name: changelog:minor
+    color: ffffff
+    description: Minor change resulting in a minor release
+    # from_name: minor  # uncomment if converting from previous labels
+  - name: changelog:patch
+    color: ffffff
+    description: Patch change resulting in a patch release
+    # from_name: patch  # uncomment if converting from previous labels
+  - name: changelog:skip
+    color: ffffff
+    description: Don't include this pull request in the release change log
+    # from_name: skip-changelog  # uncomment if converting from previous labels
   - name: dependencies
     color: 0366d6
     description: Pull request that updates a dependency file
@@ -18,11 +34,9 @@
     color: 84b6eb
     description: Request or pull request for a new feature
   - name: github_actions
-    color: 000000
+    color: '000000'
     description: Pull requests that update Github_actions code
-  - name: github/workflows
-    color: ffffff
-    description: Update to GitHub Action Workflow
+    # from_name: github/workflows  # uncomment if converting from previous labels
   - name: good first issue
     color: 7057ff
     description: Good for newcomers
@@ -38,15 +52,6 @@
   - name: maintenance
     color: fbca04
     description: General repo or CI/CD upkeep
-  - name: major
-    color: ffffff
-    description: Major change resulting in a major release
-  - name: minor
-    color: ffffff
-    description: Minor change resulting in a minor release
-  - name: patch
-    color: ffffff
-    description: Patch change resulting in a patch release
   - name: poetry
     color: '306998'
     description: Update to Poetry configuration
@@ -71,9 +76,6 @@
   - name: release
     color: e4e669
     description: A release task or pull request
-  - name: skip-changelog
-    color: ffffff
-    description: Don't include this pull request in the release change log
   - name: status:abandoned
     color: '000000'
     description: Issue or pull request abandoned by author

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,7 +16,7 @@ autolabeler:  # cspell:ignore autolabeler
     branch: [/^(feat|feature)\/.*/]
   - label: maintenance
     branch: [/^(chore|maint|maintain|maintenance)\/.*/]
-  - label: patch
+  - label: changelog:patch
     branch: [/^(bug|bugfix|fix|hotfix)\/.*/]
   - label: poetry
     files:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -30,7 +30,7 @@ autolabeler:  # cspell:ignore autolabeler
       - setup.cfg
   - label: release
     branch: [/^(release)\/.*/]
-  - label: workflows
+  - label: github_actions
     files:
       - .github/workflows/*.yml
 categories:
@@ -54,7 +54,7 @@ category-template: >-
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 commitish: master  # cspell:ignore commitish
 exclude-labels:
-  - skip-changelog
+  - changelog:skip
   - release
 name-template: v$RESOLVED_VERSION
 sort-direction: ascending
@@ -66,11 +66,11 @@ template: |
 version-resolver:
   major:
     labels:
-      - major
+      - changelog:major
   minor:
     labels:
-      - minor
+      - changelog:minor
   patch:
     labels:
-      - patch
+      - changelog:patch
   default: patch

--- a/.github/workflows/label-maker.yml
+++ b/.github/workflows/label-maker.yml
@@ -24,4 +24,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml
           skip-delete: false
-          dry-run: ${{ github.ref != 'refs/heads/master' }}
+          # dry-run: ${{ github.ref != 'refs/heads/master' }}
+          dry-run: false

--- a/.github/workflows/label-maker.yml
+++ b/.github/workflows/label-maker.yml
@@ -24,5 +24,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml
           skip-delete: false
-          # dry-run: ${{ github.ref != 'refs/heads/master' }}
-          dry-run: false
+          dry-run: ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
# Why This Is Needed

dependabot is hardcoded (can't be configured or disabled) to label PRs with `major`, `minor`, `patch` based on the dependency version change if the labels exist in the repo.

release-drafter uses these labels to determine what the next release version will be. However, release-drafter can be configured to use different labels.

# What Changed

## Changed

- renamed `major` label to `changelog:major`
- renamed `minor` label to `changelog:minor`
- renamed `patch` label to `changelog:patch`
- renamed `skip-changelog` label to `changelog:skip`
