### PR TITLE
docs: add js script to open external links in a new tab

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,0 +1,4 @@
+// open external links in new tabs
+$(document).ready(function () {
+  $('a.external').attr('target', '_blank');
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,7 @@ html_css_files = [
     "css/rtd_dark.css",
     # 'css/code_one_dark.scss'
 ]
+html_js_files = ["js/custom.js"]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
# Summary

External links in documentation generated by Sphinx will now be opened in a new tab.

# What Changed

## Added

- added `docs/source/_static/js/custom.js` with code to change the functionality of external links
- added `html_js_files` field to `docs/source/config.py`
