### PR TITLE
editorconfig: fix invalid config caused by an extra character

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_size = 4
 [*.json]
 indent_size = 4
 
-[*.{html,md,rst,xml,yml,yaml}}]
+[*.{html,md,rst,xml,yml,yaml}]
 indent_size = 2
 
 [*.py]


### PR DESCRIPTION
# What Changed

## Fixed

- fixed `.editorconfig` by removing an unnecessary character
