### PR TITLE
remove pre-commit default language

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.8
-
 minimum_pre_commit_version: 2.13.0
 
 repos:


### PR DESCRIPTION
# Why This Is Needed

Having this set caused issues on systems that did not have Python 3.8 installed.