### PR TITLE
rename setup.cfg to .flake8 as it is only used for flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -32,7 +32,7 @@ extend-ignore =
     E203,
     # line break before operator
     W503
-ignore-decorators = overload
-max-line-length = 98
+ignore-decorators = abstractmethod|overload
+max-line-length = 120
 show-source = true
 statistics = true


### PR DESCRIPTION
# What Changed

## Changed

- changed flake8 line length to 120
- flake8 will now ignore the `@abstractmethod` decorator
